### PR TITLE
move std::move from C++11 to C++14 section

### DIFF
--- a/ArxTypeTraits/type_traits.h
+++ b/ArxTypeTraits/type_traits.h
@@ -146,13 +146,6 @@ namespace arx { namespace arx_std {
 
 
     template <class T>
-    constexpr typename remove_reference<T>::type&& move(T&& t) noexcept
-    {
-        return static_cast<typename remove_reference<T>::type&&>(t);
-    }
-
-
-    template <class T>
     constexpr T&& forward(typename remove_reference<T>::type& t) noexcept
     {
         return static_cast<T&&>(t);
@@ -451,6 +444,11 @@ namespace arx { namespace arx_std {
     template<typename... Ts>
     using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
 
+    template <class T>
+    constexpr typename remove_reference<T>::type&& move(T&& t) noexcept
+    {
+        return static_cast<typename remove_reference<T>::type&&>(t);
+    }
 } } // namespace arx::arx_std
 
 #endif // Do not have libstdc++14


### PR DESCRIPTION
In C++14, std::move was changed to be constexpr. Since the version
declared by ArxTypeTraits is (now) also constexpr, it should be declared
in the C++14 section. This means if the standard library supports only
C++11, the C++14 constexpr version is still available (must be
referenced as arx::arx_std::move in this case, since we can't replace
`std::move`).

In practice, newer gcc versions actually expose the `constexpr` versions
even when C++14 is not enabled, so it does not really matter there, but
this could help in older versions that do not support C++14 at all yet.